### PR TITLE
feat: Display last updated timestamp for coaching advice

### DIFF
--- a/app.js
+++ b/app.js
@@ -2408,6 +2408,8 @@ class App {
         const refreshCoachingBtn = document.getElementById('refresh-coaching');
         if (refreshCoachingBtn) {
             refreshCoachingBtn.addEventListener('click', () => {
+                // 強制的に新しいアドバイスを生成するために、保存されたデータを削除
+                localStorage.removeItem('coachingAdvice');
                 this.generateAIRecommendations();
             });
         }
@@ -2421,13 +2423,19 @@ class App {
     
     loadAIRecommendations() {
         try {
-            const goalsData = localStorage.getItem('goals');
-            const goals = goalsData ? JSON.parse(goalsData) : [];
-            
-            if (goals.length === 0) {
-                this.showNoRecommendationsMessage();
+            const savedAdviceData = localStorage.getItem('coachingAdvice');
+            if (savedAdviceData) {
+                const coachingAdvice = JSON.parse(savedAdviceData);
+                this.renderAIRecommendations(coachingAdvice.advice, coachingAdvice.goal, coachingAdvice.timestamp);
             } else {
-                this.generateAIRecommendations();
+                const goalsData = localStorage.getItem('goals');
+                const goals = goalsData ? JSON.parse(goalsData) : [];
+
+                if (goals.length === 0) {
+                    this.showNoRecommendationsMessage();
+                } else {
+                    this.generateAIRecommendations();
+                }
             }
         } catch (error) {
             console.warn('Failed to load AI recommendations:', error);
@@ -2487,7 +2495,16 @@ class App {
             const prompt = this.generateCoachingPrompt(priorityGoal, selectedGameData);
             const response = await this.geminiService.sendChatMessage(prompt, false);
             
-            this.renderAIRecommendations(response.response, priorityGoal);
+            // アドバイスとタイムスタンプを保存
+            const coachingAdvice = {
+                advice: response.response,
+                goal: priorityGoal,
+                timestamp: new Date().toISOString()
+            };
+            localStorage.setItem('coachingAdvice', JSON.stringify(coachingAdvice));
+
+            // 保存されたデータをロードして表示
+            this.loadAIRecommendations();
             
         } catch (error) {
             console.warn('AI recommendations generation failed:', error);
@@ -2541,16 +2558,16 @@ class App {
 3. 今日実践できること（50文字以内）`;
     }
     
-    renderAIRecommendations(aiResponse, goal) {
+    renderAIRecommendations(aiResponse, goal, timestamp) {
         const recommendationsContent = document.getElementById('ai-recommendations-content');
         if (!recommendationsContent) return;
-        
+
         // AIレスポンスを解析
         const lines = aiResponse.split('\n').filter(line => line.trim());
         let actionPlan = '';
         let effectiveness = '';
         let todayAction = '';
-        
+
         lines.forEach(line => {
             if (line.includes('1.') || line.includes('行動指針')) {
                 actionPlan = line.replace(/^[1.]?\s*/, '').replace(/行動指針[：:]?\s*/, '');
@@ -2560,20 +2577,22 @@ class App {
                 todayAction = line.replace(/^[3.]?\s*/, '').replace(/今日.*?[：:]?\s*/, '');
             }
         });
-        
+
         // デフォルト値を設定
         if (!actionPlan) actionPlan = aiResponse.substring(0, 100) + '...';
         if (!effectiveness) effectiveness = 'コーチング理論に基づく効果的なアプローチです';
         if (!todayAction) todayAction = '練習を始めてみましょう';
-        
+
+        const formattedTimestamp = timestamp ? this.formatTimestamp(timestamp) : '更新日時不明';
+
         recommendationsContent.innerHTML = `
             <div class="coaching-advice-card">
-                <div class="advice-header">
+                 <div class="advice-header">
                     <div class="goal-focus">
                         <span class="goal-icon">🎯</span>
                         <span class="goal-title">目標: ${goal.title}</span>
                     </div>
-                    <div class="goal-deadline">期限: ${new Date(goal.deadline).toLocaleDateString('ja-JP')}</div>
+                    <div class="coaching-timestamp">${formattedTimestamp}</div>
                 </div>
                 
                 <div class="advice-content">
@@ -2594,6 +2613,17 @@ class App {
                 </div>
             </div>
         `;
+    }
+
+    formatTimestamp(isoString) {
+        if (!isoString) return '';
+        const date = new Date(isoString);
+        const year = date.getFullYear();
+        const month = (date.getMonth() + 1).toString().padStart(2, '0');
+        const day = date.getDate().toString().padStart(2, '0');
+        const hours = date.getHours().toString().padStart(2, '0');
+        const minutes = date.getMinutes().toString().padStart(2, '0');
+        return `${year}/${month}/${day} ${hours}:${minutes}`;
     }
     
     showOfflineRecommendations(goals, gameData) {

--- a/styles.css
+++ b/styles.css
@@ -919,7 +919,7 @@ body {
 
 .ai-header {
   display: flex;
-  justify-content: between;
+  justify-content: space-between;
   align-items: center;
   margin-bottom: var(--spacing-lg);
 }
@@ -3209,12 +3209,24 @@ input, select, textarea {
 }
 
 .advice-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-lg);
-  padding-bottom: var(--spacing-md);
-  border-bottom: 1px solid rgba(233, 69, 96, 0.2);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-lg);
+    padding-bottom: var(--spacing-md);
+    border-bottom: 1px solid rgba(233, 69, 96, 0.2);
+    gap: 1rem;
+}
+
+.advice-header .goal-focus {
+    margin-right: auto;
+}
+
+.coaching-timestamp {
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .goal-focus {


### PR DESCRIPTION
This commit introduces a feature to display the last updated time for the "Coaching Advice" on the dashboard.

Key changes:
- When new coaching advice is generated, the content and the current timestamp are saved to `localStorage`.
- The application now loads the advice from `localStorage` on page load.
- The timestamp is displayed on the dashboard in "YYYY/MM/DD HH:mm" format.
- If a timestamp is not available (e.g., for advice generated before this change), it displays "更新日時不明" (Last update time unknown).
- Added CSS to correctly position the timestamp to the right of the section title.