### PR TITLE
feat: Add timestamp to coaching advice and fix prompt leak

### DIFF
--- a/app.js
+++ b/app.js
@@ -2493,7 +2493,7 @@ class App {
             
             // Gemini AIからアドバイスを取得
             const prompt = this.generateCoachingPrompt(priorityGoal, selectedGameData);
-            const response = await this.geminiService.sendChatMessage(prompt, false);
+            const response = await this.geminiService.generateSingleResponse(prompt);
             
             // アドバイスとタイムスタンプを保存
             const coachingAdvice = {

--- a/gemini-service.js
+++ b/gemini-service.js
@@ -258,6 +258,59 @@ ${goals.length > 0 ? goals.map(g => `- ${g.title} (期限: ${g.deadline})`).join
         }
     }
 
+    // 単一の応答を生成（履歴なし）
+    async generateSingleResponse(prompt) {
+        if (!this.isConfigured()) {
+            throw new Error('Gemini APIキーが設定されていません');
+        }
+
+        try {
+            const context = this.getGameContext();
+            const systemPrompt = this.generateSystemPrompt(context);
+
+            const messages = [
+                { role: 'user', parts: [{ text: systemPrompt }] },
+                { role: 'model', parts: [{ text: 'eSportsコーチとして、あなたをサポートします。何でも聞いてください！' }] },
+                { role: 'user', parts: [{ text: prompt }] }
+            ];
+
+            const requestBody = {
+                contents: messages,
+                generationConfig: this.chatParams
+            };
+
+            const response = await fetch(`${this.baseUrl}/models/${this.chatModel}:generateContent?key=${this.apiKey}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.error?.message || `HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+
+            if (!data.candidates || data.candidates.length === 0) {
+                throw new Error('APIから有効な応答が得られませんでした');
+            }
+
+            const aiResponse = data.candidates[0].content.parts[0].text;
+
+            return {
+                response: aiResponse,
+                usage: data.usageMetadata || {}
+            };
+
+        } catch (error) {
+            console.error('Gemini single response error:', error);
+            throw error;
+        }
+    }
+
     // 画像分析
     async analyzeImage(imageData, fileName, gameContext = null) {
         if (!this.isConfigured()) {


### PR DESCRIPTION
This commit introduces a feature to display the last updated time for the "Coaching Advice" on the dashboard, and also fixes a critical bug where chat history could leak into the coaching advice prompt.

Timestamp Feature:
- When new coaching advice is generated, the content and the current timestamp are saved to `localStorage`.
- The application now loads the advice from `localStorage` on page load.
- The timestamp is displayed on the dashboard in "YYYY/MM/DD HH:mm" format.
- If a timestamp is not available, it displays "更新日時不明" (Last update time unknown).
- Added CSS to correctly position the timestamp.

Bug Fix:
- Created a new `generateSingleResponse` function in `gemini-service.js` that does not interact with the chat history.
- Updated the coaching advice generation in `app.js` to use this new function, isolating it from the main chat and preventing prompt contamination.